### PR TITLE
Track non-enhanced assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,37 @@ If `false`, empower-core mimics originalAssert as new object/function, so `origi
 
 
 #### options.onError
-
-| type       | default value |
-|:-----------|:--------------|
-| `function` | (function defined in `empowerCore.defaultOptions()`) |
-
-TBD
-
-
 #### options.onSuccess
 
 | type       | default value |
 |:-----------|:--------------|
 | `function` | (function defined in `empowerCore.defaultOptions()`) |
 
-TBD
+Both methods are called with a single `event` argument, it will have the following properties:
 
+- `event.enhanced` - `true` for methods matching `patterns`. `false` for methods matching `wrapOnlyPatterns`.
+
+- `event.originalMessage` - The actual value the user provided for optional `message` parameter. This will be `undefined` if the user did not provide a value, even if the underlying assertion provides a default message.
+
+- `event.args` - An array of the actual arguments passed to the assertion.
+
+- `event.assertionThrew` - Whether or not the underlying assertion threw an error. This will always be `true` in an `onError` callback, and always `false` in an `onSuccess` callback.
+
+- `event.error` - Only present if `event.assertionThrew === true`. Contains the error thrown by the underlying assertion method.
+
+- `event.returnValue` - Only present if `event.assertionThrew === false`. Contains the value return value returned by the underlying assertion method.
+
+- `event.powerAssertContext` - Only present for methods that match `patterns`, and only in code that has been enhanced with the power-assert transform. It contains the information necessary for power-assert renderers to generate their output. Implementors of `onError` should usually attach it to the error object
+
+  ```js
+  function onError (errorEvent) {
+    var e = errorEvent.error;
+    if (errorEvent.powerAssertContext && e.name === 'AssertionError') {
+        e.powerAssertContext = errorEvent.powerAssertContext;
+    }
+    throw e;
+  }
+  ```
 
 #### options.modifyMessageBeforeAssert
 
@@ -123,6 +138,14 @@ TBD
 Target patterns for power assert feature instrumentation.
 
 Pattern detection is done by [call-signature](https://github.com/jamestalmage/call-signature). Any arguments enclosed in bracket (for example, `[message]`) means optional parameters. Without bracket means mandatory parameters.
+
+#### options.wrapOnlyPatterns
+
+| type                | default value       |
+|:--------------------|:--------------------|
+| `Array` of `string` | empty array         |
+
+Methods matching these patterns will not be instrumented by the code transform, but they will be wrapped at runtime and trigger events in the `onSuccess` and `onError` callbacks. Note that "wrap only" events will never have a `powerAssertContext` property.
 
 
 ### var options = empowerCore.defaultOptions();

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -8,6 +8,7 @@ function decorate (callSpec, decorator) {
     var func = callSpec.func;
     var thisObj = callSpec.thisObj;
     var numArgsToCapture = callSpec.numArgsToCapture;
+    var enhanced = callSpec.enhanced;
 
     return function decoratedAssert () {
         var context, message, hasMessage = false, args = slice.apply(arguments);
@@ -22,7 +23,8 @@ function decorate (callSpec, decorator) {
             func: func,
             values: args,
             message: message,
-            hasMessage: hasMessage
+            hasMessage: hasMessage,
+            enhanced: enhanced
         };
 
         if (some(args, isCaptured)) {

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -62,15 +62,15 @@ Decorator.prototype.concreteAssert = function (invocation, context) {
         ret = func.apply(thisObj, args);
     } catch (e) {
         if (context) {
-            return this.onError({error: e, originalMessage: message, powerAssertContext: context});
+            return this.onError({type: 'error', error: e, originalMessage: message, powerAssertContext: context});
         } else {
-            return this.onError({error: e, originalMessage: message, args: args});
+            return this.onError({type: 'error', error: e, originalMessage: message, args: args});
         }
     }
     if (context) {
-        return this.onSuccess({returnValue: ret, originalMessage: message, powerAssertContext: context});
+        return this.onSuccess({type: 'success', returnValue: ret, originalMessage: message, powerAssertContext: context});
     } else {
-        return this.onSuccess({returnValue: ret, originalMessage: message, args: args});
+        return this.onSuccess({type: 'success', returnValue: ret, originalMessage: message, args: args});
     }
 };
 

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -13,22 +13,37 @@ function Decorator (receiver, config) {
     this.onError = config.onError;
     this.onSuccess = config.onSuccess;
     this.signatures = map(config.patterns, signature.parse);
+    this.addtionalMethods = map(config.additionalMethods, signature.parse);
 }
 
 Decorator.prototype.enhancement = function () {
     var that = this;
     var container = this.container();
-    forEach(filter(this.signatures, methodCall), function (matcher) {
+    var wrappedMethods = [];
+
+    function attach(matcher, enhanced) {
         var methodName = detectMethodName(matcher.callee);
-        if (typeof that.receiver[methodName] === 'function') {
-            var callSpec = {
-                thisObj: that.receiver,
-                func: that.receiver[methodName],
-                numArgsToCapture: numberOfArgumentsToCapture(matcher)
-            };
-            container[methodName] = decorate(callSpec, that);
+        if (typeof that.receiver[methodName] !== 'function' || wrappedMethods.indexOf(methodName) !== -1) {
+            return;
         }
+        var callSpec = {
+            thisObj: that.receiver,
+            func: that.receiver[methodName],
+            numArgsToCapture: numberOfArgumentsToCapture(matcher),
+            enhanced: enhanced
+        };
+        container[methodName] = decorate(callSpec, that);
+        wrappedMethods.push(methodName);
+    }
+
+    forEach(filter(this.signatures, methodCall), function (matcher) {
+        attach(matcher, true);
     });
+
+    forEach(filter(this.addtionalMethods, methodCall), function (matcher) {
+        attach(matcher, false);
+    });
+
     return container;
 };
 
@@ -36,11 +51,17 @@ Decorator.prototype.container = function () {
     var basement = {};
     if (typeof this.receiver === 'function') {
         var candidates = filter(this.signatures, functionCall);
+        var enhanced = true;
+        if (candidates.length === 0) {
+            enhanced = false;
+            candidates = filter(this.addtionalMethods, functionCall);
+        }
         if (candidates.length === 1) {
             var callSpec = {
                 thisObj: null,
                 func: this.receiver,
-                numArgsToCapture: numberOfArgumentsToCapture(candidates[0])
+                numArgsToCapture: numberOfArgumentsToCapture(candidates[0]),
+                enhanced: enhanced
             };
             basement = decorate(callSpec, this);
         }
@@ -53,25 +74,33 @@ Decorator.prototype.concreteAssert = function (invocation, context) {
     var thisObj = invocation.thisObj;
     var args = invocation.values;
     var message = invocation.message;
+    var enhanced = invocation.enhanced;
     if (context && typeof this.config.modifyMessageBeforeAssert === 'function') {
         message = this.config.modifyMessageBeforeAssert({originalMessage: message, powerAssertContext: context});
     }
     args = args.concat(message);
+
+    var data = {
+        originalMessage: message,
+        enhanced: enhanced,
+        args: args
+    };
+
+    if (context) {
+        data.powerAssertContext = context;
+    }
+
     var ret;
     try {
         ret = func.apply(thisObj, args);
     } catch (e) {
-        if (context) {
-            return this.onError({type: 'error', error: e, originalMessage: message, powerAssertContext: context});
-        } else {
-            return this.onError({type: 'error', error: e, originalMessage: message, args: args});
-        }
+        data.type = 'error';
+        data.error = e;
+        return this.onError(data);
     }
-    if (context) {
-        return this.onSuccess({type: 'success', returnValue: ret, originalMessage: message, powerAssertContext: context});
-    } else {
-        return this.onSuccess({type: 'success', returnValue: ret, originalMessage: message, args: args});
-    }
+    data.type = 'success';
+    data.returnValue = ret;
+    return this.onSuccess(data);
 };
 
 function numberOfArgumentsToCapture (matcher) {

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -13,7 +13,7 @@ function Decorator (receiver, config) {
     this.onError = config.onError;
     this.onSuccess = config.onSuccess;
     this.signatures = map(config.patterns, signature.parse);
-    this.addtionalMethods = map(config.additionalMethods, signature.parse);
+    this.wrapOnlySignatures = map(config.wrapOnlyPatterns, signature.parse);
 }
 
 Decorator.prototype.enhancement = function () {
@@ -40,7 +40,7 @@ Decorator.prototype.enhancement = function () {
         attach(matcher, true);
     });
 
-    forEach(filter(this.addtionalMethods, methodCall), function (matcher) {
+    forEach(filter(this.wrapOnlySignatures, methodCall), function (matcher) {
         attach(matcher, false);
     });
 
@@ -54,7 +54,7 @@ Decorator.prototype.container = function () {
         var enhanced = true;
         if (candidates.length === 0) {
             enhanced = false;
-            candidates = filter(this.addtionalMethods, functionCall);
+            candidates = filter(this.wrapOnlySignatures, functionCall);
         }
         if (candidates.length === 1) {
             var callSpec = {
@@ -94,11 +94,11 @@ Decorator.prototype.concreteAssert = function (invocation, context) {
     try {
         ret = func.apply(thisObj, args);
     } catch (e) {
-        data.type = 'error';
+        data.assertionThrew = true;
         data.error = e;
         return this.onError(data);
     }
-    data.type = 'success';
+    data.assertionThrew = false;
     data.returnValue = ret;
     return this.onSuccess(data);
 };

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -17,7 +17,7 @@ module.exports = function defaultOptions () {
             'assert.deepStrictEqual(actual, expected, [message])',
             'assert.notDeepStrictEqual(actual, expected, [message])'
         ],
-        additionalMethods: []
+        wrapOnlyPatterns: []
     };
 };
 

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -16,7 +16,8 @@ module.exports = function defaultOptions () {
             'assert.notDeepEqual(actual, expected, [message])',
             'assert.deepStrictEqual(actual, expected, [message])',
             'assert.notDeepStrictEqual(actual, expected, [message])'
-        ]
+        ],
+        additionalMethods: []
     };
 };
 

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -443,6 +443,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'error');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Where did you learn math?');
+        baseAssert.strictEqual(event.type, 'error');
         baseAssert(event.error instanceof baseAssert.AssertionError, 'instanceof AssertionError');
         baseAssert(event.powerAssertContext, 'has a powerAssertContext');
     });
@@ -454,6 +455,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'success');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Good job!');
+        baseAssert.strictEqual(event.type, 'success');
         baseAssert(event.powerAssertContext, 'has a powerAssertContext');
     });
 
@@ -464,6 +466,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'error');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Maybe in an alternate universe.');
+        baseAssert.strictEqual(event.type, 'error');
         baseAssert(event.error instanceof baseAssert.AssertionError, 'instanceof AssertionError');
         baseAssert(!event.powerAssertContext, 'does not have a powerAssertContext');
         baseAssert.deepEqual(event.args, [4, 5, 'Maybe in an alternate universe.'], 'attaches event.args');
@@ -476,6 +479,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'success');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Gold star!');
+        baseAssert.strictEqual(event.type, 'success');
         baseAssert(!event.powerAssertContext, 'does not have a powerAssertContext');
         baseAssert.deepEqual(event.args, [4, 4, 'Gold star!'], 'attaches event.args');
     });

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -443,7 +443,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'error');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Where did you learn math?');
-        baseAssert.strictEqual(event.type, 'error');
+        baseAssert.strictEqual(event.assertionThrew, true);
         baseAssert(event.error instanceof baseAssert.AssertionError, 'instanceof AssertionError');
         baseAssert(event.powerAssertContext, 'has a powerAssertContext');
     });
@@ -455,7 +455,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'success');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Good job!');
-        baseAssert.strictEqual(event.type, 'success');
+        baseAssert.strictEqual(event.assertionThrew, false);
         baseAssert(event.powerAssertContext, 'has a powerAssertContext');
     });
 
@@ -466,7 +466,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'error');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Maybe in an alternate universe.');
-        baseAssert.strictEqual(event.type, 'error');
+        baseAssert.strictEqual(event.assertionThrew, true);
         baseAssert(event.error instanceof baseAssert.AssertionError, 'instanceof AssertionError');
         baseAssert(!event.powerAssertContext, 'does not have a powerAssertContext');
         baseAssert.deepEqual(event.args, [4, 5, 'Maybe in an alternate universe.'], 'attaches event.args');
@@ -479,7 +479,7 @@ suite('custom logging event handlers', function () {
         baseAssert.strictEqual(log[0][0], 'success');
         var event = log[0][1][0];
         baseAssert.strictEqual(event.originalMessage, 'Gold star!');
-        baseAssert.strictEqual(event.type, 'success');
+        baseAssert.strictEqual(event.assertionThrew, false);
         baseAssert(!event.powerAssertContext, 'does not have a powerAssertContext');
         baseAssert.deepEqual(event.args, [4, 4, 'Gold star!'], 'attaches event.args');
     });
@@ -517,7 +517,7 @@ suite('onSuccess can throw', function () {
     });
 });
 
-suite('additionalMethods', function () {
+suite('wrapOnlyPatterns', function () {
     var assert = empower(
       {
           fail: function (message) {
@@ -528,16 +528,16 @@ suite('additionalMethods', function () {
           }
       },
       {
-          additionalMethods: [
+          wrapOnlyPatterns: [
               'assert.fail([message])',
               'assert.pass([message])'
           ],
           onError: function (event) {
-              baseAssert.equal(event.type, 'error');
+              baseAssert.equal(event.assertionThrew, true);
               return event;
           },
           onSuccess: function (event) {
-              baseAssert.equal(event.type, 'success');
+              baseAssert.equal(event.assertionThrew, false);
               return event;
           }
       }
@@ -545,7 +545,7 @@ suite('additionalMethods', function () {
 
     test('instrumented code: success', function () {
         var event = eval(weave('assert.pass("woot!")'));
-        baseAssert.equal(event.type, 'success');
+        baseAssert.equal(event.assertionThrew, false);
         baseAssert.strictEqual(event.enhanced, false);
         baseAssert.equal(event.originalMessage, 'woot!');
         baseAssert.deepEqual(event.args, ['woot!']);
@@ -553,7 +553,7 @@ suite('additionalMethods', function () {
 
     test('instrumented code: error', function () {
         var event = eval(weave('assert.fail("Oh no!")'));
-        baseAssert.equal(event.type, 'error');
+        baseAssert.equal(event.assertionThrew, true);
         baseAssert.strictEqual(event.enhanced, false);
         baseAssert.equal(event.originalMessage, 'Oh no!');
         baseAssert.deepEqual(event.args, ['Oh no!']);
@@ -561,7 +561,7 @@ suite('additionalMethods', function () {
 
     test('non-instrumented code: success', function () {
         var event = assert.pass('woot!');
-        baseAssert.equal(event.type, 'success');
+        baseAssert.equal(event.assertionThrew, false);
         baseAssert.strictEqual(event.enhanced, false);
         baseAssert.equal(event.originalMessage, 'woot!');
         baseAssert.deepEqual(event.args, ['woot!']);
@@ -569,7 +569,7 @@ suite('additionalMethods', function () {
 
     test('non-instrumented code: error', function () {
         var event = assert.fail('Oh no!');
-        baseAssert.equal(event.type, 'error');
+        baseAssert.equal(event.assertionThrew, true);
         baseAssert.strictEqual(event.enhanced, false);
         baseAssert.equal(event.originalMessage, 'Oh no!');
         baseAssert.deepEqual(event.args, ['Oh no!']);

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -517,4 +517,63 @@ suite('onSuccess can throw', function () {
     });
 });
 
+suite('additionalMethods', function () {
+    var assert = empower(
+      {
+          fail: function (message) {
+              baseAssert.ok(false, message);
+          },
+          pass: function (message) {
+              // noop
+          }
+      },
+      {
+          additionalMethods: [
+              'assert.fail([message])',
+              'assert.pass([message])'
+          ],
+          onError: function (event) {
+              baseAssert.equal(event.type, 'error');
+              return event;
+          },
+          onSuccess: function (event) {
+              baseAssert.equal(event.type, 'success');
+              return event;
+          }
+      }
+    );
+
+    test('instrumented code: success', function () {
+        var event = eval(weave('assert.pass("woot!")'));
+        baseAssert.equal(event.type, 'success');
+        baseAssert.strictEqual(event.enhanced, false);
+        baseAssert.equal(event.originalMessage, 'woot!');
+        baseAssert.deepEqual(event.args, ['woot!']);
+    });
+
+    test('instrumented code: error', function () {
+        var event = eval(weave('assert.fail("Oh no!")'));
+        baseAssert.equal(event.type, 'error');
+        baseAssert.strictEqual(event.enhanced, false);
+        baseAssert.equal(event.originalMessage, 'Oh no!');
+        baseAssert.deepEqual(event.args, ['Oh no!']);
+    });
+
+    test('non-instrumented code: success', function () {
+        var event = assert.pass('woot!');
+        baseAssert.equal(event.type, 'success');
+        baseAssert.strictEqual(event.enhanced, false);
+        baseAssert.equal(event.originalMessage, 'woot!');
+        baseAssert.deepEqual(event.args, ['woot!']);
+    });
+
+    test('non-instrumented code: error', function () {
+        var event = assert.fail('Oh no!');
+        baseAssert.equal(event.type, 'error');
+        baseAssert.strictEqual(event.enhanced, false);
+        baseAssert.equal(event.originalMessage, 'Oh no!');
+        baseAssert.deepEqual(event.args, ['Oh no!']);
+    });
+});
+
 }));


### PR DESCRIPTION
This provides another option called `additionalMethods`. This is for methods **not** intended to be "enhanced" by the transform, but where we **do** want to allow our `onSuccess` and `onError` callbacks to wrap and manipulate the assertion results.

For example, `assert.throws` is not an assertion we can really provide a good renderer for, but it would be helpful (at least to AVA) to use the `onSuccess` and `onError` callbacks to track when those assertions are used.
