### PR TITLE
Allow prototype enhancements.

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -16,6 +16,7 @@ function decorate (callSpec, decorator) {
         }
 
         var invocation = {
+            thisObj: this,
             values: args,
             message: message,
             hasMessage: hasMessage

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -75,7 +75,7 @@ Decorator.prototype.container = function () {
 
 Decorator.prototype.concreteAssert = function (callSpec, invocation, context) {
     var func = callSpec.func;
-    var thisObj = callSpec.thisObj;
+    var thisObj = this.config.bindReceiver ? callSpec.thisObj : invocation.thisObj;
     var enhanced = callSpec.enhanced;
     var args = invocation.values;
     var message = invocation.message;
@@ -87,6 +87,7 @@ Decorator.prototype.concreteAssert = function (callSpec, invocation, context) {
     args = args.concat(message);
 
     var data = {
+        thisObj: invocation.thisObj,
         assertionFunction: callSpec.enhancedFunc,
         originalMessage: message,
         defaultMessage: matcherSpec.defaultMessage,
@@ -105,11 +106,11 @@ Decorator.prototype.concreteAssert = function (callSpec, invocation, context) {
     } catch (e) {
         data.assertionThrew = true;
         data.error = e;
-        return this.onError(data);
+        return this.onError.call(thisObj, data);
     }
     data.assertionThrew = false;
     data.returnValue = ret;
-    return this.onSuccess(data);
+    return this.onSuccess.call(thisObj, data);
 };
 
 function numberOfArgumentsToCapture (matcherSpec) {

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -3,6 +3,7 @@
 module.exports = function defaultOptions () {
     return {
         destructive: false,
+        bindReceiver: true,
         onError: onError,
         onSuccess: onSuccess,
         patterns: [

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -644,4 +644,47 @@ suite('wrapOnlyPatterns', function () {
     });
 });
 
+suite('enhancing a prototype', function () {
+    test('you can enhance a prototype', function () {
+        function AssertionApi(name) {
+            this.name = name;
+            this.assertions = [];
+        }
+
+        AssertionApi.prototype.name = 'prototype';
+
+        AssertionApi.prototype.equal = function (actual, expected, message) {
+            this.assertions.push(actual + ' == ' + expected);
+            baseAssert.equal(actual, expected, message);
+        };
+
+        function onAssertion(event) {
+            baseAssert.strictEqual(this, event.thisObj);
+            return event.thisObj;
+        }
+
+        empower(AssertionApi.prototype, {
+            patterns: [
+                'assert.equal(actual, expected, [message])'
+            ],
+            destructive: true,
+            bindReceiver: false,
+            onSuccess: onAssertion,
+            onError: onAssertion
+        });
+
+        var assertA = new AssertionApi('foo');
+        var assertB = new AssertionApi('bar');
+
+        var a = assertA.equal('a', 'a');
+        var b = assertB.equal('b', 'b');
+
+        baseAssert.deepEqual(assertA.assertions, ['a == a']);
+        baseAssert.deepEqual(assertB.assertions, ['b == b']);
+
+        baseAssert.strictEqual(a, assertA);
+        baseAssert.strictEqual(b, assertB);
+    });
+});
+
 }));


### PR DESCRIPTION
AVA currently creates an enhanced assertion object each time. This is costly. This allows prototype enhancement by adding a `bindReceiver` option. 

Setting `bindReceiver` to `true` (the default), assertion methods have their `this` value bound to the original assertion object.

Setting `bindReceiver` to false causes the `this` reference to captured at the actual time of invocation. This allows the enhancement of prototypes.

@twada - Hold off on merging until I confirm performance improvements.

Reference: 
 https://github.com/sindresorhus/ava/issues/460
