### PR TITLE
Optimizations: don't leak arguments.

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -2,13 +2,18 @@
 
 var some = require('core-js/library/fn/array/some');
 var map = require('core-js/library/fn/array/map');
-var slice = Array.prototype.slice;
 
 function decorate (callSpec, decorator) {
     var numArgsToCapture = callSpec.numArgsToCapture;
 
     return function decoratedAssert () {
-        var context, message, hasMessage = false, args = slice.apply(arguments);
+        var context, message, hasMessage = false;
+
+        // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+        var args = new Array(arguments.length);
+        for(var i = 0; i < args.length; ++i) {
+            args[i] = arguments[i];
+        }
 
         if (numArgsToCapture === (args.length - 1)) {
             message = args.pop();

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -100,6 +100,10 @@ Decorator.prototype.concreteAssert = function (callSpec, invocation, context) {
         data.powerAssertContext = context;
     }
 
+    return this._callFunc(func, thisObj, args, data);
+};
+
+Decorator.prototype._callFunc = function (func, thisObj, args, data) {
     var ret;
     try {
         ret = func.apply(thisObj, args);


### PR DESCRIPTION
It seems counter intuitive, but apparently this is faster.
I did see minor improvements (5%) in the AVA benchmark I was doing.

Reference:
  https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
