### PR TITLE
Fix: dealing with `err.name` on Node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "5"
   - "6"
 before_install:
-  - "npm install -g gulp"
   - "npm install -g bower"
   # - "npm install -g coveralls"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"
+  - "7"
+  - "8"
 before_install:
   - "npm install -g bower"
   # - "npm install -g coveralls"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Both methods are called with a single `event` argument, it will have the followi
   ```js
   function onError (errorEvent) {
     var e = errorEvent.error;
-    if (errorEvent.powerAssertContext && e.name === 'AssertionError') {
+    if (errorEvent.powerAssertContext && /^AssertionError/.test(e.name)) {
         e.powerAssertContext = errorEvent.powerAssertContext;
     }
     throw e;

--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ Then load (`empowerCore` function is exported)
     <script type="text/javascript" src="./path/to/bower_components/empower-core/build/empower-core.js"></script>
 
 
+OUR SUPPORT POLICY
+---------------------------------------
+
+We support Node under maintenance. In other words, we stop supporting old Node version when [their maintenance ends](https://github.com/nodejs/LTS).
+
+We also support "modern enough" browsers such as Chrome, Firefox, Safari, Edge etc.
+
+Any other environments are not supported officially (means that we do not test against them on CI service). empower-core is known to work with old browsers, and trying to keep them working though.
+
+
 AUTHOR
 ---------------------------------------
 * [Takuto Wada](https://github.com/twada)

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -24,7 +24,7 @@ module.exports = function defaultOptions () {
 
 function onError (errorEvent) {
     var e = errorEvent.error;
-    if (errorEvent.powerAssertContext && e.name === 'AssertionError') {
+    if (errorEvent.powerAssertContext && /^AssertionError/.test(e.name)) {
         e.powerAssertContext = errorEvent.powerAssertContext;
     }
     throw e;

--- a/test/buster_assertions_test.js
+++ b/test/buster_assertions_test.js
@@ -77,7 +77,7 @@
                 'assert(falsy)',
                 '[{"value":0,"espath":"arguments/0"}]'
             ].join('\n'));
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 
@@ -94,7 +94,7 @@
                     'assert.isNull(falsy)',
                     '[{"value":0,"espath":"arguments/0"}]: Expected 0 to be null'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
     });
@@ -112,7 +112,7 @@
                     'assert.same(foo, bar)',
                     '[{"value":"foo","espath":"arguments/0"},{"value":"bar","espath":"arguments/1"}]: foo expected to be the same object as bar'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
 
@@ -127,7 +127,7 @@
                     'assert.same("foo", bar)',
                     '[{"value":"bar","espath":"arguments/1"}]: foo expected to be the same object as bar'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
 
@@ -142,7 +142,7 @@
                     'assert.same(foo, "bar")',
                     '[{"value":"foo","espath":"arguments/0"}]: foo expected to be the same object as bar'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
     });
@@ -160,7 +160,7 @@
                     'assert.near(actualVal, expectedVal, delta)',
                     '[{"value":10.6,"espath":"arguments/0"},{"value":10,"espath":"arguments/1"},{"value":0.5,"espath":"arguments/2"}]: Expected 10.6 to be equal to 10 +/- 0.5'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
 
@@ -175,7 +175,7 @@
                     'assert.near(actualVal, expectedVal, delta, messageStr)',
                     '[{"value":10.6,"espath":"arguments/0"},{"value":10,"espath":"arguments/1"},{"value":0.5,"espath":"arguments/2"}]: Expected 10.6 to be equal to 10 +/- 0.5'
                 ].join('\n'));
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             }
         });
     });

--- a/test/empower_test.js
+++ b/test/empower_test.js
@@ -68,7 +68,7 @@ test('default options behavior', function () {
                 }
             ]
         });
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -95,7 +95,7 @@ test('Bug reproduction. should not fail if argument is null Literal.', function 
                 }
             ]
         });
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -121,7 +121,7 @@ test('assertion with optional message argument.', function () {
                 }
             ]
         });
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -147,7 +147,7 @@ test('empowered function also acts like an assert function', function () {
                 }
             ]
         });
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 
@@ -174,7 +174,7 @@ suite('assertion method with one argument', function () {
                     }
                 ]
             });
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 });
@@ -204,7 +204,7 @@ suite('assertion method with two arguments', function () {
                     }
                 ]
             });
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 
@@ -227,7 +227,7 @@ suite('assertion method with two arguments', function () {
                     }
                 ]
             });
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 
@@ -250,7 +250,7 @@ suite('assertion method with two arguments', function () {
                     }
                 ]
             });
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
         }
     });
 });
@@ -281,7 +281,7 @@ suite('yield for assertion inside generator', function () {
                         }
                     ]
                 });
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             } catch (e) {
                 return done (e);
             }
@@ -334,7 +334,7 @@ suite('await assertion inside async async function', function () {
                         }
                     ]
                 });
-                baseAssert.equal(e.name, 'AssertionError');
+                baseAssert(/^AssertionError/.test(e.name));
             } catch (e) {
                 return done (e);
             }
@@ -380,7 +380,7 @@ test('the case when assertion function call is not listed in patterns (even if m
         baseAssert.ok(false, 'AssertionError should be thrown');
     } catch (e) {
         baseAssert.equal(e.message, '0 == true', 'should not be empowered');
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
     }
 });
 

--- a/test/not_espowered_case_test.js
+++ b/test/not_espowered_case_test.js
@@ -22,7 +22,7 @@ test('argument is null Literal.', function () {
         eval('assert.equal(foo, null);');
         assert.ok(false, 'AssertionError should be thrown');
     } catch (e) {
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
         baseAssert((e.message === '\'foo\' == null' || e.message === '\"foo\" == null'));
         baseAssert(e.powerAssertContext === undefined);
     }
@@ -35,7 +35,7 @@ test('empowered function also acts like an assert function', function () {
         eval('assert(falsy);');
         assert.ok(false, 'AssertionError should be thrown');
     } catch (e) {
-        baseAssert.equal(e.name, 'AssertionError');
+        baseAssert(/^AssertionError/.test(e.name));
         baseAssert.equal(e.message, '0 == true');
         baseAssert(e.powerAssertContext === undefined);
     }
@@ -49,7 +49,7 @@ suite('assertion method with one argument', function () {
             eval('assert.ok(falsy);');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert.equal(e.message, '0 == true');
             baseAssert(e.powerAssertContext === undefined);
         }
@@ -64,7 +64,7 @@ suite('assertion method with two arguments', function () {
             eval('assert.equal(foo, bar);');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert((e.message === '\'foo\' == \'bar\'' || e.message === '\"foo\" == \"bar\"'));
             baseAssert(e.powerAssertContext === undefined);
         }
@@ -76,7 +76,7 @@ suite('assertion method with two arguments', function () {
             eval('assert.equal("foo", bar);');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert((e.message === '\'foo\' == \'bar\'' || e.message === '\"foo\" == \"bar\"'));
             baseAssert(e.powerAssertContext === undefined);
         }
@@ -88,7 +88,7 @@ suite('assertion method with two arguments', function () {
             eval('assert.equal(foo, "bar");');
             assert.ok(false, 'AssertionError should be thrown');
         } catch (e) {
-            baseAssert.equal(e.name, 'AssertionError');
+            baseAssert(/^AssertionError/.test(e.name));
             baseAssert((e.message === '\'foo\' == \'bar\'' || e.message === '\"foo\" == \"bar\"'));
             baseAssert(e.powerAssertContext === undefined);
         }


### PR DESCRIPTION
v8's e.name contains error code like `AssertionError [ERR_ASSERTION]`